### PR TITLE
Add missing space

### DIFF
--- a/code-conventions.md
+++ b/code-conventions.md
@@ -1,7 +1,7 @@
 # Code conventions
 
 {% hint style="danger" %}
-This guide is written with fp-ts v2 in mind. To understand if a snippet found in the wild is v1 or v2 refer to[this migration guide](https://gcanti.github.io/fp-ts/introduction/upgrade-to-v2.html).
+This guide is written with fp-ts v2 in mind. To understand if a snippet found in the wild is v1 or v2 refer to [this migration guide](https://gcanti.github.io/fp-ts/introduction/upgrade-to-v2.html).
 {% endhint %}
 
 fp-ts uses an approach ef exporting every single function from the module, to avoid name collision is better to import all the module and use an alias


### PR DESCRIPTION
Noticed another missing space in the top part of the code conventions page.